### PR TITLE
Parse BESS CORE block and allow memory mapped IO register checking

### DIFF
--- a/framework/unit_checker.py
+++ b/framework/unit_checker.py
@@ -33,7 +33,16 @@ def exec_rule(rule):
     exec('global rule_result; rule_result = {:s}'.format(rule))
     return rule_result
 
-mem_map = { 'WRAM': 0xC000, 'VRAM': 0x8000, 'OAM': 0xFE00, 'HRAM': 0xFF80 }
+
+mem_map = {
+    'VRAM': 0x8000,
+    'WRAM': 0xC000,
+    'OAM': 0xFE00,
+    'IO_REG': 0xFF00,
+    'HRAM': 0xFF80,
+}
+
+
 def ADDR(symbol, base):
     if type(base) is str:
         base = mem_map[base.upper()]

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,11 @@
 # Simple unit test system for GBDK
 
-To add a new test just write some .c file, which contains the 
+To add a new test just write some .c file, which contains the
 
-`void test() {
-}`
+```c
+void test() {
+}
+```
 
 function implementation and also a .json file with the same name, that describes the result of a test. Look at the examples, and make similarly.
 

--- a/test-io-reg.c
+++ b/test-io-reg.c
@@ -1,0 +1,10 @@
+#include <gb/gb.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "framework/main.h"
+
+void test(void) {
+  NR33_REG = 0x36;
+  delay(100);
+}

--- a/test-io-reg.json
+++ b/test-io-reg.json
@@ -1,0 +1,4 @@
+{
+  "description": "Test the state of an IO register",
+  "rules": ["DATA('IO_REG', ADDR('_NR33_REG', 'IO_REG')) == 0x36"]
+}


### PR DESCRIPTION
This allows one to check the state of registers e.g. `_NR33_REG`

```python
DATA('IO_REG', ADDR('_NR33_REG', 'IO_REG')) == 0x36
```

Used the BESS spec here: https://github.com/LIJI32/SameBoy/blob/master/BESS.md#core-block

Not tied to the name `IO_REG`, of course.